### PR TITLE
Hotfix/steam id length

### DIFF
--- a/lib/is.js
+++ b/lib/is.js
@@ -76,7 +76,7 @@ var util = require('./util');
  */
 (function () {
     var name = '[\\w-]{2,32}';
-    var id = '[0-9]{17}';
+    var id = '[0-9]{16,18}';
 
     def({
         fn: 'steam.name',
@@ -163,7 +163,7 @@ var util = require('./util');
  * @return {RegExp}
  */
 function url (subpattern) {
-    return new RegExp('^http(s)?:\\/\\/(www\\.)?' + subpattern + '/?(\\?.*)?$', 'i');
+    return new RegExp('^https?:\\/\\/(www\\.)?' + subpattern + '/?(\\?.*)?$', 'i');
 }
 
 /**

--- a/lib/is.js
+++ b/lib/is.js
@@ -163,7 +163,7 @@ var util = require('./util');
  * @return {RegExp}
  */
 function url (subpattern) {
-    return new RegExp('^https?:\\/\\/(www\\.)?' + subpattern + '/?(\\?.*)?$', 'i');
+    return new RegExp('^http(s)?:\\/\\/(www\\.)?' + subpattern + '/?(\\?.*)?$', 'i');
 }
 
 /**

--- a/lib/is.js
+++ b/lib/is.js
@@ -76,7 +76,7 @@ var util = require('./util');
  */
 (function () {
     var name = '[\\w-]{2,32}';
-    var id = '[0-9]{16}';
+    var id = '[0-9]{17}';
 
     def({
         fn: 'steam.name',

--- a/test/is.test.js
+++ b/test/is.test.js
@@ -145,32 +145,32 @@ describe('`is`', function () {
         },
         'checks valid steam profile id': {
             fn: 'steam.profileUrl',
-            checkThat: 'https://steamcommunity.com/profiles/12345678901234567',
+            checkThat: 'http://steamcommunity.com/profiles/12345678901234567',
             is: true
         },
         'checks valid steam profile id with trailing slash': {
             fn: 'steam.profileUrl',
-            checkThat: 'https://steamcommunity.com/profiles/12345678901234567/',
+            checkThat: 'http://steamcommunity.com/profiles/12345678901234567/',
             is: true
         },
         'checks invalid steam profile id': {
             fn: 'steam.profileUrl',
-            checkThat: 'https://steamcommunity.com/profiles/abcdefgh123',
+            checkThat: 'http://steamcommunity.com/profiles/abcdefgh123',
             is: false
         },
         'checks valid steam name': {
             fn: 'steam.customUrl',
-            checkThat: 'https://steamcommunity.com/id/abcdefgh123',
+            checkThat: 'http://steamcommunity.com/id/abcdefgh123',
             is: true
         },
         'checks valid steam name with trailing slash': {
             fn: 'steam.customUrl',
-            checkThat: 'https://steamcommunity.com/id/abcdefgh123/',
+            checkThat: 'http://steamcommunity.com/id/abcdefgh123/',
             is: true
         },
         'checks invalid steam name': {
             fn: 'steam.customUrl',
-            checkThat: 'https://steamcommunity.com/id/',
+            checkThat: 'http://steamcommunity.com/id/',
             is: false
         },
         'checks valid instagram name': {

--- a/test/is.test.js
+++ b/test/is.test.js
@@ -145,12 +145,12 @@ describe('`is`', function () {
         },
         'checks valid steam profile id': {
             fn: 'steam.profileUrl',
-            checkThat: 'https://steamcommunity.com/profiles/1234567890123456',
+            checkThat: 'https://steamcommunity.com/profiles/12345678901234567',
             is: true
         },
         'checks valid steam profile id with trailing slash': {
             fn: 'steam.profileUrl',
-            checkThat: 'https://steamcommunity.com/profiles/1234567890123456/',
+            checkThat: 'https://steamcommunity.com/profiles/12345678901234567/',
             is: true
         },
         'checks invalid steam profile id': {


### PR DESCRIPTION
Steam ID is actually 17 numbers long. Not 16 like was originally assumed.

Also, Steam URLs are not backed by SSL.  Configuring the url regex accordingly.